### PR TITLE
Add checking for whether a role has permissions

### DIFF
--- a/discordui.go
+++ b/discordui.go
@@ -556,9 +556,11 @@ func (this *DiscordUI) ExtractUserID(s string) string {
 	}
 }
 
+// Returns whether the role should be assignable by the bot.
+// This is done by checking if the role is both below the bot in the role list and has no permissions granted
 func (this *DiscordUI) assignableRole(role *discordgo.Role, botHighRole int) (assignable bool) {
 	assignable = false
-	if role.Position < botHighRole {
+	if (role.Position < botHighRole) && (role.Permissions == 0) {
 		assignable = this.assignableRoleName(role.Name)
 	}
 	return


### PR DESCRIPTION
Adds a check to confirm a role has zero permissions before allowing it to be added. Also adds doc comment to that function. I tested this by giving the bot administrator and moving it to the top of the role list, and then verifying I could only see roles the bot was meant to be able to modify.

Resolves #3 