### PR TITLE
Fix issues with role assignment in join command

### DIFF
--- a/discordui.go
+++ b/discordui.go
@@ -584,12 +584,11 @@ func (this *DiscordUI) assignableRoleName(roleName string) (assignable bool) {
 	return
 }
 
+// Get all of the roles from the servers the bot is part of.
+// This will need to be updated if the bot is ever in more than 200 servers,
+// because that is the max.
 func (this *DiscordUI) getAllGuildRoles() {
-	joinedGuilds, err := this.session.UserGuilds(200, "", "", false)
-	if err != nil {
-		fmt.Printf("Error calling getGuildRoles: %s", err.Error())
-		return
-	}
+	joinedGuilds := this.session.State.Guilds
 	guildRoles := make(map[string][]*discordgo.Role)
 	for _, g := range joinedGuilds {
 		guild, err := this.session.Guild(g.ID)
@@ -604,6 +603,7 @@ func (this *DiscordUI) getAllGuildRoles() {
 	this.guildRoles = guildRoles
 }
 
+// Update the guild roles for the given guild, guildID.
 func (this *DiscordUI) updateGuildRoles(guildID string) {
 	guild, err := this.session.Guild(guildID)
 	if err == nil {

--- a/discordui.go
+++ b/discordui.go
@@ -68,6 +68,9 @@ func (this *DiscordUI) Run() {
 
 	this.readyHandlerRemove = discord.AddHandler(this.ready)
 	this.interactionCreateHandlerRemove = discord.AddHandler(this.interactionCreate)
+	discord.AddHandler(this.guildRoleCreateHandler)
+	discord.AddHandler(this.guildRoleDeleteHandler)
+	discord.AddHandler(this.guildRoleUpdateHandler)
 
 	var minColorLen, maxColorLen int = 3, 7
 	var adminPermission int64 = 0x08
@@ -608,4 +611,22 @@ func (this *DiscordUI) updateGuildRoles(guildID string) {
 	} else {
 		fmt.Printf("Error calling updateGuildRoles: %s", err.Error())
 	}
+}
+
+func (this *DiscordUI) guildRoleCreateHandler(_ *discordgo.Session, event *discordgo.GuildRoleCreate) {
+	gid := event.GuildRole.GuildID
+	this.updateGuildRoles(gid)
+	fmt.Printf("Role creation detected. Updated roles for ID: %s", gid)
+}
+
+func (this *DiscordUI) guildRoleDeleteHandler(_ *discordgo.Session, event *discordgo.GuildRoleDelete) {
+	gid := event.GuildID
+	this.updateGuildRoles(gid)
+	fmt.Printf("Role delete detected. Updated roles for ID: %s", gid)
+}
+
+func (this *DiscordUI) guildRoleUpdateHandler(_ *discordgo.Session, event *discordgo.GuildRoleUpdate) {
+	gid := event.GuildRole.GuildID
+	this.updateGuildRoles(gid)
+	fmt.Printf("Role update detected. Updated roles for ID: %s", gid)
 }

--- a/discordui.go
+++ b/discordui.go
@@ -217,17 +217,14 @@ func (this *DiscordUI) interactionCreate(s *discordgo.Session, ic *discordgo.Int
 				partialName := strings.ToLower(options[0].StringValue())
 				// search for partialName in roles which the bot can assign which don't look like a user ID
 				var choices []*discordgo.ApplicationCommandOptionChoice = make([]*discordgo.ApplicationCommandOptionChoice, 0)
-				if groles, err := s.GuildRoles(ic.GuildID); err != nil {
-					fmt.Printf("Error calling GuildRoles(%v): %v\n", ic.GuildID, err.Error())
-				} else {
-					if botm, err := s.GuildMember(targGuild, this.botID); err == nil {
-						botHighRole := this.findBotRole(groles, botm)
-						for _, role := range groles {
-							if this.assignableRole(role, botHighRole) && strings.Contains(strings.ToLower(role.Name), partialName) {
-								// this is a possible choice
-								if !leaving || (leaving && this.hasRolePtr(ic.Member, role)) {
-									choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: role.Name, Value: role.Name})
-								}
+				groles := this.guildRoles[targGuild]
+				if botm, err := s.GuildMember(targGuild, this.botID); err == nil {
+					botHighRole := this.findBotRole(groles, botm)
+					for _, role := range groles {
+						if this.assignableRole(role, botHighRole) && strings.Contains(strings.ToLower(role.Name), partialName) {
+							// this is a possible choice
+							if !leaving || (leaving && this.hasRolePtr(ic.Member, role)) {
+								choices = append(choices, &discordgo.ApplicationCommandOptionChoice{Name: role.Name, Value: role.Name})
 							}
 						}
 					}
@@ -609,24 +606,24 @@ func (this *DiscordUI) updateGuildRoles(guildID string) {
 	if err == nil {
 		this.guildRoles[guildID] = guild.Roles
 	} else {
-		fmt.Printf("Error calling updateGuildRoles: %s", err.Error())
+		fmt.Printf("Error calling updateGuildRoles: %s\n", err.Error())
 	}
 }
 
 func (this *DiscordUI) guildRoleCreateHandler(_ *discordgo.Session, event *discordgo.GuildRoleCreate) {
 	gid := event.GuildRole.GuildID
 	this.updateGuildRoles(gid)
-	fmt.Printf("Role creation detected. Updated roles for ID: %s", gid)
+	fmt.Printf("Role creation detected. Updated roles for ID: %s\n", gid)
 }
 
 func (this *DiscordUI) guildRoleDeleteHandler(_ *discordgo.Session, event *discordgo.GuildRoleDelete) {
 	gid := event.GuildID
 	this.updateGuildRoles(gid)
-	fmt.Printf("Role delete detected. Updated roles for ID: %s", gid)
+	fmt.Printf("Role delete detected. Updated roles for ID: %s\n", gid)
 }
 
 func (this *DiscordUI) guildRoleUpdateHandler(_ *discordgo.Session, event *discordgo.GuildRoleUpdate) {
 	gid := event.GuildRole.GuildID
 	this.updateGuildRoles(gid)
-	fmt.Printf("Role update detected. Updated roles for ID: %s", gid)
+	fmt.Printf("Role update detected. Updated roles for ID: %s\n", gid)
 }

--- a/discordui.go
+++ b/discordui.go
@@ -284,10 +284,6 @@ func (this *DiscordUI) interactionCreate(s *discordgo.Session, ic *discordgo.Int
 }
 
 func (this *DiscordUI) handleJoinCommand(interaction *discordgo.Interaction, targGuild string, member *discordgo.Member, groupParam string) {
-	// TODO: Change this to use the cached version of the role list.
-	// TODO: Case insensitive search.
-	// TODO: Give message when a role isn't assignable.
-	// TODO: Edit assignableRole() to handle case of a role not existing. (Helper function maybe?)
 	s := this.session
 	response := ""
 	// mroles := member.Roles

--- a/discordui.go
+++ b/discordui.go
@@ -284,67 +284,53 @@ func (this *DiscordUI) interactionCreate(s *discordgo.Session, ic *discordgo.Int
 }
 
 func (this *DiscordUI) handleJoinCommand(interaction *discordgo.Interaction, targGuild string, member *discordgo.Member, groupParam string) {
+	// TODO: Change this to use the cached version of the role list.
+	// TODO: Case insensitive search.
+	// TODO: Give message when a role isn't assignable.
+	// TODO: Edit assignableRole() to handle case of a role not existing. (Helper function maybe?)
 	s := this.session
 	response := ""
-	mroles := member.Roles
-	groles, err := s.GuildRoles(targGuild)
+	// mroles := member.Roles
+	groles := this.guildRoles[targGuild]
 	groupParam = strings.TrimPrefix(groupParam, "@")
+	botm, err := s.GuildMember(targGuild, this.botID)
 	if err != nil {
-		response = "Failed to retrieve list of guild roles: " + err.Error()
+		response = fmt.Sprintf("Unable to find guild member %s (the bot) in guild %s", this.botID, targGuild)
 	} else {
-		botm, err := s.GuildMember(targGuild, this.botID)
-		if err != nil {
-			response = fmt.Sprintf("Unable to find guild member %s (the bot) in guild %s", this.botID, targGuild)
-		} else {
-			botHighRole := this.findBotRole(groles, botm)
-			var roleFound *discordgo.Role = nil
-			fmt.Printf("Searching roles for %v.\n", groupParam)
-			for i := 0; i < len(groles); i++ {
-				if groles[i].Name == groupParam {
-					roleFound = groles[i]
-					break
-				}
-			}
-			if roleFound != nil {
-				if this.assignableRole(roleFound, botHighRole) {
-					// make sure they don't already have the role
-					hasRole := false
-					for i := 0; i < len(mroles); i++ {
-						if mroles[i] == groupParam {
-							hasRole = true
-							break
-						}
-					}
-					if !hasRole {
-						// assign the user to the specified role
-						err = s.GuildMemberRoleAdd(targGuild, member.User.ID, roleFound.ID)
-						if err != nil {
-							response = fmt.Sprintf("Failed to assign new role %s: %s", roleFound.Name, err.Error())
-						} else {
-							response = fmt.Sprintf("Added %v to `@%v`", member.DisplayName(), roleFound.Name)
-						}
-					}
-				}
-			} else if this.assignableRoleName(groupParam) {
-				// create a new role with the specified name
-				newColor := 0xe67e22
-				hoist := false
-				var permissions int64 = 0
-				mentionable := true
-				roleParams := &discordgo.RoleParams{Name: groupParam, Color: &newColor, Hoist: &hoist, Permissions: &permissions, Mentionable: &mentionable}
-				if role, err := s.GuildRoleCreate(targGuild, roleParams); err != nil {
-					response = fmt.Sprintf("Failed to create new role %v: %v", groupParam, err.Error())
+		botHighRole := this.findBotRole(groles, botm)
+		var roleFound *discordgo.Role = nil
+		fmt.Printf("Searching roles for %v.\n", groupParam)
+		roleFound = this.guildHasRole(groupParam, groles)
+		if roleFound != nil {
+			if this.assignableRole(roleFound, botHighRole) {
+				err = s.GuildMemberRoleAdd(targGuild, member.User.ID, roleFound.ID)
+				if err != nil {
+					response = fmt.Sprintf("Failed to assign new role %s: %s", roleFound.Name, err.Error())
 				} else {
-					err = s.GuildMemberRoleAdd(targGuild, member.User.ID, role.ID)
-					if err != nil {
-						response = fmt.Sprintf("Failed to assign new role %s: %s", role.Name, err.Error())
-					} else {
-						response = this.sortGuildRoles(groles, s, targGuild, role, botm, true, fmt.Sprintf("Added %v to new role `@%v`.", member.DisplayName(), role.Name))
-					}
+					response = fmt.Sprintf("Added %v to `@%v`", member.DisplayName(), roleFound.Name)
 				}
 			} else {
 				response = fmt.Sprintf("Unable to assign role: %s", groupParam)
 			}
+		} else if this.assignableRoleName(groupParam) {
+			// create a new role with the specified name
+			newColor := 0xe67e22
+			hoist := false
+			var permissions int64 = 0
+			mentionable := true
+			roleParams := &discordgo.RoleParams{Name: groupParam, Color: &newColor, Hoist: &hoist, Permissions: &permissions, Mentionable: &mentionable}
+			if role, err := s.GuildRoleCreate(targGuild, roleParams); err != nil {
+				response = fmt.Sprintf("Failed to create new role %v: %v", groupParam, err.Error())
+			} else {
+				err = s.GuildMemberRoleAdd(targGuild, member.User.ID, role.ID)
+				if err != nil {
+					response = fmt.Sprintf("Failed to assign new role %s: %s", role.Name, err.Error())
+				} else {
+					response = this.sortGuildRoles(groles, s, targGuild, role, botm, true, fmt.Sprintf("Added %v to new role `@%v`.", member.DisplayName(), role.Name))
+				}
+			}
+		} else {
+			response = fmt.Sprintf("Unable to assign role: %s", groupParam)
 		}
 	}
 	respData := &discordgo.InteractionResponseData{Content: response,
@@ -663,4 +649,16 @@ func (this *DiscordUI) guildRoleUpdateHandler(_ *discordgo.Session, event *disco
 	gid := event.GuildRole.GuildID
 	this.updateGuildRoles(gid)
 	fmt.Printf("Role update detected. Updated roles for ID: %s\n", gid)
+}
+
+func (this *DiscordUI) guildHasRole(roleName string, roles []*discordgo.Role) (role *discordgo.Role) {
+	role = nil
+	roleName = strings.ToLower(roleName)
+	for _, r := range roles {
+		if strings.ToLower(r.Name) == roleName {
+			role = r
+			break
+		}
+	}
+	return
 }


### PR DESCRIPTION
Fixes #2 

Update join roles to prevent duplicate role creation.
Use cached version of role list.